### PR TITLE
Fix encrypted_conversation_signature

### DIFF
--- a/src/EdgeGPT/EdgeGPT.py
+++ b/src/EdgeGPT/EdgeGPT.py
@@ -52,6 +52,7 @@ class Chatbot:
         with open(filename, "w") as f:
             conversation_id = self.chat_hub.request.conversation_id
             conversation_signature = self.chat_hub.request.conversation_signature
+            encrypted_conversation_signature = self.chat_hub.request.encrypted_conversation_signature
             client_id = self.chat_hub.request.client_id
             invocation_id = self.chat_hub.request.invocation_id
             f.write(
@@ -59,6 +60,7 @@ class Chatbot:
                     {
                         "conversation_id": conversation_id,
                         "conversation_signature": conversation_signature,
+                        "encrypted_conversation_signature": encrypted_conversation_signature,
                         "client_id": client_id,
                         "invocation_id": invocation_id,
                     },
@@ -73,6 +75,7 @@ class Chatbot:
             conversation = json.load(f)
             self.chat_hub.request = ChatHubRequest(
                 conversation_signature=conversation["conversation_signature"],
+                encrypted_conversation_signature=conversation["encrypted_conversation_signature"],
                 client_id=conversation["client_id"],
                 conversation_id=conversation["conversation_id"],
                 invocation_id=conversation["invocation_id"],
@@ -205,6 +208,7 @@ class Chatbot:
         self,
         conversation_id: str = None,
         conversation_signature: str = None,
+        encrypted_conversation_signature: str = None,
         client_id: str = None,
     ) -> None:
         """
@@ -213,6 +217,7 @@ class Chatbot:
         await self.chat_hub.delete_conversation(
             conversation_id=conversation_id,
             conversation_signature=conversation_signature,
+            encrypted_conversation_signature=encrypted_conversation_signature,
             client_id=client_id,
         )
 

--- a/src/EdgeGPT/request.py
+++ b/src/EdgeGPT/request.py
@@ -13,6 +13,7 @@ class ChatHubRequest:
     def __init__(
         self,
         conversation_signature: str,
+        encrypted_conversation_signature: str,
         client_id: str,
         conversation_id: str,
         invocation_id: int = 3,
@@ -22,6 +23,7 @@ class ChatHubRequest:
         self.client_id: str = client_id
         self.conversation_id: str = conversation_id
         self.conversation_signature: str = conversation_signature
+        self.encrypted_conversation_signature: str = encrypted_conversation_signature
         self.invocation_id: int = invocation_id
 
     def update(
@@ -123,6 +125,7 @@ class ChatHubRequest:
                     "tone": conversation_style.name.capitalize(),  # Make first letter uppercase
                     "requestId": message_id,
                     "conversationSignature": self.conversation_signature,
+                    "encryptedConversationSignature": self.encrypted_conversation_signature,
                     "participant": {
                         "id": self.client_id,
                     },


### PR DESCRIPTION
Currently, conversations' history did not work. Therefore, I made these changes so that encrypted_conversation_signature is stored in the conversation file and loaded from it